### PR TITLE
fixing pointer bug in the selector

### DIFF
--- a/WSSWIRS/QuickBucket.hpp
+++ b/WSSWIRS/QuickBucket.hpp
@@ -261,7 +261,7 @@ public:
             }
             if (!major_flag) {
                 int left_range = largest_bucket_id - 2 * log2_ceil(ele_size);
-                for (auto i : bucket_map) {
+                for (auto& i : bucket_map) {
                     if (i.first < left_range) {
                         if (random_bucket_weight <= i.second.bucket_weight) {
                             cur_bucket = &i.second;


### PR DESCRIPTION
This ensures that, in the for loop used to select a bucket, i is a reference to an entry in the bucket map instead of a copy. That way, cur_bucket does not point to a copy of an object that stops existing when the loop ends. This avoids undefined behavior. 